### PR TITLE
Fix hardcoded "ca" path in ssl config.

### DIFF
--- a/templates/root_openssl.cnf.j2
+++ b/templates/root_openssl.cnf.j2
@@ -13,8 +13,8 @@ serial            = $dir/serial
 RANDFILE          = $dir/private/.rand
 
 # The root key and root certificate.
-private_key       = $dir/private/ca.key.pem
-certificate       = $dir/certs/ca.cert.pem
+private_key       = $dir/private/{{ openssl_pki_ca_name }}.key.pem
+certificate       = $dir/certs/{{ openssl_pki_ca_name }}.cert.pem
 
 # For certificate revocation lists.
 crlnumber         = $dir/crlnumber


### PR DESCRIPTION
Setting openssl_pki_ca_name to a non default value would fail at the step "Generate intermediate certificate" and give a file not found. Inspecting the directory showed that we had a mismatch between the actual file (openssl_pki_ca_name.key.pem) and the  expected (ca.key.pem)